### PR TITLE
Added netg.eval() for inference mode, to fix the behaviour of Batchnorm

### DIFF
--- a/lib/model.py
+++ b/lib/model.py
@@ -181,6 +181,7 @@ class BaseModel():
         Raises:
             IOError: Model weights not found.
         """
+        self.netg.eval()
         with torch.no_grad():
             # Load the weights of netg and netd.
             if self.opt.load_weights:


### PR DESCRIPTION
Added netg.eval() for inference mode, to fix the behaviour of Batchnorm. Without this line, batch statistics are used during inference. Instead, we want to use running statistics during inference.