### PR TITLE
fix hardcoded output path

### DIFF
--- a/lib/model.py
+++ b/lib/model.py
@@ -184,7 +184,7 @@ class BaseModel():
         with torch.no_grad():
             # Load the weights of netg and netd.
             if self.opt.load_weights:
-                path = "./output/{}/{}/train/weights/netG.pth".format(self.name.lower(), self.opt.dataset)
+                path = "{}/{}/{}/train/weights/netG.pth".format(self.opt.outf, self.name.lower(), self.opt.dataset)
                 pretrained_dict = torch.load(path)['state_dict']
 
                 try:


### PR DESCRIPTION
I think _outf_ path is hardcoded in _test_ method.

from
`path = "./output/{}/{}/train/weights/netG.pth".format(self.name.lower(), self.opt.dataset)`    

to
`path = "{}/{}/{}/train/weights/netG.pth".format(self.opt.outf, self.name.lower(), self.opt.dataset)`                

This should fix the bug.